### PR TITLE
Fix for script typos

### DIFF
--- a/authorization_code/public/index.html
+++ b/authorization_code/public/index.html
@@ -82,13 +82,13 @@
             userProfileTemplate = Handlebars.compile(userProfileSource),
             userProfilePlaceholder = document.getElementById('user-profile');
 
-            oauthSource = document.getElementById('oauth-template').innerHTML,
+        var oauthSource = document.getElementById('oauth-template').innerHTML,
             oauthTemplate = Handlebars.compile(oauthSource),
             oauthPlaceholder = document.getElementById('oauth');
 
         var params = getHashParams();
 
-        var access_token = params.access_token
+        var access_token = params.access_token,
             refresh_token = params.refresh_token,
             error = params.error;
 


### PR DESCRIPTION
There are a var and a comma missing in the inline scripts in the index.html. 
Nothing major, but I've been told to leave things better than I found them ;)
